### PR TITLE
support for reference objects

### DIFF
--- a/lib/php_serialize.rb
+++ b/lib/php_serialize.rb
@@ -315,6 +315,9 @@ private
 			when 'b' # bool, b:0 or 1
 				val = (string.read(2)[0] == ?1 ? true : false)
 
+			when 'r' # reference to another object, r:45
+				val = string.read_until(';').to_i
+
 			else
 				raise TypeError, "Unable to unserialize type '#{type}'"
 		end

--- a/test.rb
+++ b/test.rb
@@ -128,6 +128,13 @@ class TestPhpSerialize < Test::Unit::TestCase
 		end
 	end
 
+	def test_reference
+		php = 'a:1:{s:3:"uid";r:45;}'
+		ruby = {"uid" => 45}
+		unserialized = PHP.unserialize(php)
+		assert_equal ruby, unserialized
+	end
+
   def test_new_struct_creation
     assert_nothing_raised do
       phps = 'O:8:"stdClass":2:{s:3:"url";s:17:"/legacy/index.php";s:8:"dateTime";s:19:"2012-10-24 22:29:13";}'


### PR DESCRIPTION
Added support for r type reference where according to [this](http://www.phpinternalsbook.com/classes_objects/serialization.html) guide:

> As objects in PHP exhibit a reference-like behavior serialize also makes sure that the same object occurring twice will really be the same object on unserialization:
> 
> ```
> $o = new stdClass;
> $o->foo = $o;
> ```
> 
> O:8:"stdClass":1:{s:3:"foo";r:1;}
> As you can see it works the same way as with references, just using the small r instead of R.

Maybe support for capital R can be added, i just haven't come across a usage yet,
